### PR TITLE
Dynamic fat

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -20,7 +20,6 @@ pub fn add_file(args: &[String])
     };
 
     let mut image = fat::Image::from_file(image_name.clone())?;
-    let bpb = image.bios_parameter();
 
     // Don't overwrite a preexisting file.
     if let Ok(_) = image.get_file_entry(file_name.clone()) {
@@ -34,7 +33,7 @@ pub fn add_file(args: &[String])
     let (entry, index) = image.create_file_entry(fat_file_name)?;
 
     // Get free FAT entries, fill sectors with file data.
-    for chunk in &file.bytes().chunks(bpb.bytes_per_sector as usize) {
+    for chunk in &file.bytes().chunks(image.sector_size()) {
         let chunk = chunk
             .map(|b_res| b_res.unwrap_or(0))
             .collect::<Vec<_>>();

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -19,7 +19,7 @@ pub fn add_file(args: &[String])
         file_name.clone()
     };
 
-    let mut image = fat::Image::from(image_name.clone())?;
+    let mut image = fat::Image::from_file(image_name.clone())?;
     let bpb = image.bios_parameter();
 
     // Don't overwrite a preexisting file.

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -20,6 +20,7 @@ pub fn add_file(args: &[String])
     };
 
     let mut image = fat::Image::from(image_name.clone())?;
+    let bpb = image.bios_parameter();
 
     // Don't overwrite a preexisting file.
     if let Ok(_) = image.get_file_entry(file_name.clone()) {
@@ -33,7 +34,7 @@ pub fn add_file(args: &[String])
     let (entry, index) = image.create_file_entry(fat_file_name)?;
 
     // Get free FAT entries, fill sectors with file data.
-    for chunk in &file.bytes().chunks(fat::BYTES_PER_SECTOR) {
+    for chunk in &file.bytes().chunks(bpb.bytes_per_sector as usize) {
         let chunk = chunk
             .map(|b_res| b_res.unwrap_or(0))
             .collect::<Vec<_>>();

--- a/src/commands/detail.rs
+++ b/src/commands/detail.rs
@@ -8,7 +8,7 @@ pub fn detail_file(args: &[String])
     expect_args!(args, 2);
 
     let image_fn = args[0].clone();
-    let image = fat::Image::from(image_fn)?;
+    let image = fat::Image::from_file(image_fn)?;
 
     let file_metadata = image.get_file_entry(args[1].clone())?;
     println!("{:#?}", file_metadata);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -8,7 +8,7 @@ pub fn list_files(args: &[String])
     expect_args!(args, 1);
 
     let image_fn = args[0].clone();
-    let image = fat::Image::from(image_fn)?;
+    let image = fat::Image::from_file(image_fn)?;
 
     for entry in image.root_entries() {
         if entry.rest_are_free() {

--- a/src/fat/bios_param.rs
+++ b/src/fat/bios_param.rs
@@ -3,6 +3,7 @@ extern crate byteorder;
 use std::error;
 use std::fs;
 use std::io::Read;
+use std::path::Path;
 
 use self::byteorder::{LittleEndian,ByteOrder};
 
@@ -47,11 +48,11 @@ impl BIOSParam {
     }
 
     /// Extract the BIOS Parameter Block (BPB) from the FAT filesystem image.
-    pub fn from(image_fn: String)
+    pub fn from_file<P: AsRef<Path>>(p: P)
         -> Result<BIOSParam, Box<error::Error>>
     {
         let mut boot_sector: Vec<u8> = vec![0; 512];
-        let mut file = fs::File::open(image_fn)?;
+        let mut file = fs::File::open(p.as_ref())?;
 
         try!(file.read_exact(&mut boot_sector));
 

--- a/src/fat/bios_param.rs
+++ b/src/fat/bios_param.rs
@@ -1,3 +1,10 @@
+extern crate byteorder;
+
+use std::error;
+use std::fs;
+use std::io::Read;
+
+use self::byteorder::{LittleEndian,ByteOrder};
 
 #[derive(Clone,Debug)]
 
@@ -37,6 +44,36 @@ impl BIOSParam {
             media_id: 0,
             sectors_per_fat: 0,
         }
+    }
+
+    /// Extract the BIOS Parameter Block (BPB) from the FAT filesystem image.
+    pub fn from(image_fn: String)
+        -> Result<BIOSParam, Box<error::Error>>
+    {
+        let mut boot_sector: Vec<u8> = vec![0; 512];
+        let mut file = fs::File::open(image_fn)?;
+
+        try!(file.read_exact(&mut boot_sector));
+
+        let mut params = BIOSParam::new();
+
+        params.bytes_per_sector = LittleEndian::read_u16(&boot_sector[11..13]);
+        params.sectors_per_cluster = boot_sector[13];
+        params.reserved_sectors = LittleEndian::read_u16(&boot_sector[14..16]);
+        params.fat_count = boot_sector[16];
+        params.max_roots = LittleEndian::read_u16(&boot_sector[17..19]);
+        params.sectors = LittleEndian::read_u16(&boot_sector[19..21]) as u32;
+        if params.sectors == 0 {
+            // 4 byte sector count at 0x020
+            params.sectors = LittleEndian::read_u32(&boot_sector[32..37]);
+        }
+        params.media_id = boot_sector[21];
+        params.sectors_per_fat = LittleEndian::read_u16(&boot_sector[22..24]) as u32;
+        if params.sectors_per_fat == 0 {
+            // 4 byte sectors per fat count at 0x024
+            params.sectors_per_fat = LittleEndian::read_u32(&boot_sector[36..41]);
+        }
+        return Ok(params);
     }
 
     /// Reported length of FAT filesystem in bytes.

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io;
 use std::io::{Read,Write};
 use std::mem;
+use std::path::Path;
 
 use fat::RootEntry;
 use fat::BIOSParam;
@@ -46,13 +47,13 @@ impl Image {
     }
 
     /// Create a new FAT Image from the specified file.
-    pub fn from(image_fn: String)
+    pub fn from_file<P: AsRef<Path>>(p: P)
         -> Result<Image, Box<error::Error>>
     {
-        let metadata = fs::metadata(image_fn.clone())?;
-        let bpb = BIOSParam::from(image_fn.clone())?;
+        let metadata = fs::metadata(p.as_ref())?;
+        let bpb = BIOSParam::from_file(p.as_ref())?;
 
-        let mut file = fs::File::open(image_fn)?;
+        let mut file = fs::File::open(p.as_ref())?;
         let mut image = Image::new(bpb, metadata.len() as usize);
 
         try!(file.read_exact(&mut image.boot_sector));

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -33,12 +33,13 @@ pub struct Image {
 impl Image {
     /// Create a new blank FAT Image from a defined BPB
     fn new(bpb: BIOSParam) -> Image {
+        let boot_sector_size = bpb.bytes_per_sector as usize * bpb.reserved_sectors as usize;
         let bytes_per_fat = (bpb.sectors_per_fat * bpb.bytes_per_sector as u32) as usize;
         let bytes_per_root = SECTORS_PER_ROOT * bpb.bytes_per_sector as usize;
         let data_offset = bpb.bytes_per_sector as usize + (bytes_per_fat as usize * 2) + bytes_per_root as usize;
         let bytes_per_data_area = bpb.len() - data_offset;
         Image {
-            boot_sector: vec![0; bpb.bytes_per_sector as usize],
+            boot_sector: vec![0; boot_sector_size],
             fat_1: vec![0; bytes_per_fat],
             fat_2: vec![0; bytes_per_fat],
             root_dir: vec![0; bytes_per_root],

--- a/src/fat/mod.rs
+++ b/src/fat/mod.rs
@@ -2,7 +2,6 @@ mod image;
 mod root_entry;
 mod bios_param;
 
-pub use self::image::BYTES_PER_SECTOR;
 pub use self::image::Image;
 pub use self::root_entry::RootEntry;
 pub use self::bios_param::BIOSParam;


### PR DESCRIPTION
Dynamically parse the BIOS Params area of the FAT filesystem and adjust our knowledge on area sizes.

* ls tested functional on FAT12, FAT16, FAT32
* detail tested functional on FAT12, FAT16, FAT32
* add has never worked for me under rust 1.19.0, so unable to test. (#3)