### PR TITLE
New entry fix and ls cleanup

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -10,19 +10,29 @@ pub fn list_files(args: &[String])
     let image_fn = args[0].clone();
     let image = fat::Image::from_file(image_fn)?;
 
+    println!(" Volume {}", image.volume_label()?);
+    println!(" Volume has {} bytes per sector\n", image.sector_size());
+
+    let mut file_count = 0;
+    let mut size_total = 0;
     for entry in image.root_entries() {
         if entry.rest_are_free() {
             break;
-        } else if entry.is_free() {
+        } else if entry.is_free() || entry.is_volume_label() {
             continue;
         }
+        file_count += 1;
+        size_total += entry.file_size;
 
         println!(
-            "{} {}",
-            entry.filename_full(),
+            "{}\t{}\t{}\t\t{}",
+            entry.last_write_date,
+            entry.last_write_time,
             entry.file_size,
+            entry.filename().unwrap_or("????????.???".to_string()),
         );
     }
+    println!("\t{} File(s)\t\t{} bytes", file_count, size_total);
 
     Ok(())
 }

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io;
 use std::io::{Read,Write};
 use std::mem;
+use std::str;
 use std::path::Path;
 
 use fat::RootEntry;
@@ -88,6 +89,20 @@ impl Image {
     /// FAT sector size in bytes.
     pub fn sector_size(&self) -> usize {
         self.bpb_data.bytes_per_sector as usize
+    }
+
+    pub fn volume_label(&self) -> Result<String, Box<error::Error>> {
+        let entries = self.root_entries();
+        for entry in entries {
+            if !entry.is_volume_label() {
+                continue;
+            }
+            let label = format!("{}{}",
+                str::from_utf8(&entry.filename)?,
+                str::from_utf8(&entry.extension)?);
+            return Ok(label);
+        }
+        return Ok("has no label".to_string());
     }
 
     // TODO: Make this an iterator


### PR DESCRIPTION
A few things here:

 * Work to solve bug adding new files into image.  root_entries was filtering out unused entries, thus none are ever free. We solve this by adding a new function which includes all root entries (used or otherwise)
 * Add function to pluck out volume_label from image.
 * Some cleanup around the ls output to make it more like dos.  Still need to decode dates + times.