### PR TITLE
Improvements to adding files

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -51,7 +51,7 @@ pub fn add_file(args: &[String])
         }
 
         // Write chunk.
-        try!(image.write_data_sector(entry_index, &chunk));
+        image.write_data_sector(entry_index, &chunk)?;
     }
 
     image.save_file_entry(entry, index)?;

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -28,9 +28,11 @@ pub fn add_file(args: &[String])
 
     // Ensure input file exists.
     let file = fs::File::open(file_name)?;
+    let metadata = file.metadata()?;
 
     // Create a root dir entry.
-    let (entry, index) = image.create_file_entry(fat_file_name)?;
+    let (entry, index) =
+        image.create_file_entry(fat_file_name, metadata.len() as u32)?;
 
     // Get free FAT entries, fill sectors with file data.
     for chunk in &file.bytes().chunks(image.sector_size()) {

--- a/src/commands/detail.rs
+++ b/src/commands/detail.rs
@@ -13,7 +13,10 @@ pub fn detail_file(args: &[String])
     let file_metadata = image.get_file_entry(args[1].clone())?;
     println!("{:#?}", file_metadata);
 
-    let mut cluster_num = file_metadata.first_logical_cluster;
+    // XXX: We ignore the u32 entry clusters for now and cast to u16.
+    // In the future we need to convert everything to u32 for FAT32 support.
+
+    let mut cluster_num = file_metadata.entry_cluster() as u16;
     const CLUSTER_NUMS_PER_LINE: usize = 8;
     'outer: loop {
         for _ in 0 .. CLUSTER_NUMS_PER_LINE {

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -95,10 +95,10 @@ impl Image {
     }
 
     /// Save the FAT filesystem image to the specified file.
-    pub fn save(&self, image_fn: String)
+    pub fn save<P: AsRef<Path>>(&self, image_fn: P)
         -> Result<(), io::Error>
     {
-        let mut file = fs::File::create(image_fn)?;
+        let mut file = fs::File::create(image_fn.as_ref())?;
 
         try!(file.write_all(&self.boot_sector));
         try!(file.write_all(&self.fat_1));

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -258,16 +258,14 @@ impl Image {
         -> Result<(), Box<error::Error>>
     {
         let sector = sector - 2;
-        let bytes = sector * self.bpb_data.bytes_per_sector as usize;
-        if bytes >= self.data_area.len() {
+        let bytes_per_sector = self.bpb_data.bytes_per_sector as usize;
+        let start_byte = bytes_per_sector * sector;
+
+        if start_byte >= self.data_area.len() {
             return Err(From::from(format!("sector {} too high to write to", sector)))
         }
 
-        let mut target_slice = &mut self.data_area[
-            self.bpb_data.bytes_per_sector as usize * sector ..
-            self.bpb_data.bytes_per_sector as usize * (sector + 1)
-        ];
-
+        let mut target_slice = &mut self.data_area[start_byte..start_byte + data.len()];
         target_slice.copy_from_slice(data);
         Ok(())
     }

--- a/src/fat/image.rs
+++ b/src/fat/image.rs
@@ -189,14 +189,15 @@ impl Image {
     }
 
     /// Create a new RootEntry within the Image with the specified filename.
-    pub fn create_file_entry(&self, filename: String)
+    pub fn create_file_entry(&self, filename: String, bytes: u32)
         -> Result<(RootEntry, u16), Box<error::Error>>
     {
         for (index, e) in self.root_entries_all().iter().enumerate() {
             if !e.is_free() { continue; }
 
             let mut entry = RootEntry::new();
-            try!(entry.set_filename(filename));
+            entry.set_filename(filename)?;
+            entry.set_size(bytes)?;
             return Ok((entry.clone(), index as u16));
         }
 

--- a/src/fat/root_entry.rs
+++ b/src/fat/root_entry.rs
@@ -70,6 +70,13 @@ impl RootEntry {
         Ok(())
     }
 
+    pub fn set_size(&mut self, bytes: u32)
+        -> Result<(), Box<error::Error>>
+    {
+        self.file_size = bytes;
+        Ok(())
+    }
+
     pub fn is_read_only(&self)    -> bool { self.attrs & 0x01 == 0x01 }
     pub fn is_hidden(&self)       -> bool { self.attrs & 0x02 == 0x02 }
     pub fn is_system(&self)       -> bool { self.attrs & 0x04 == 0x04 }

--- a/src/fat/root_entry.rs
+++ b/src/fat/root_entry.rs
@@ -57,11 +57,15 @@ impl RootEntry {
         -> Result<(), Box<error::Error>>
     {
         let parts: Vec<_> = filename.split('.').collect();
-        if parts.len() != 2 {
+        if parts.len() != 2 || parts[0].len() > 8 || parts[1].len() > 3 {
             return Err(From::from(format!("bad filename: \"{}\"", filename)));
         }
-        self.filename.clone_from_slice(parts[0].to_uppercase().as_bytes());
-        self.extension.clone_from_slice(parts[1].to_uppercase().as_bytes());
+
+        // Pad out short filenames to proper length
+        let new_fn = format!("{:8}", parts[0].to_uppercase());
+        let new_ext = format!("{:3}", parts[1].to_uppercase());
+        self.filename.copy_from_slice(new_fn.as_bytes());
+        self.extension.copy_from_slice(new_ext.as_bytes());
 
         Ok(())
     }


### PR DESCRIPTION
* Set size of new file entries
* Entry logical sector changes for (eventual) 32-bit support.
* Improve ability to handle improperly sized filenames.
  * Errors out now instead of panic'ing if filename > 8+3.
  * Pads out filenames under 8+3 with spaces.